### PR TITLE
fix(): multiple fixes to fba-geo and fba-detailed-targeting components

### DIFF
--- a/src/app/demo-detailed-targeting/demo-detailed-targeting.component.ts
+++ b/src/app/demo-detailed-targeting/demo-detailed-targeting.component.ts
@@ -25,10 +25,16 @@ export class DemoDetailedTargetingComponent {
     'excluded_user_device':          [],
     'user_os':                       [],
     'wireless_carrier':              [],
-    /*'exclusions':                    {'interested_in': ['2']},*/
+    // 'interests':                     [
+    //   '6002979499920'
+    // ],
+    // 'behaviors':                     [
+    //   '6002714895372'
+    // ]
+    // /*'exclusions':                    {'interested_in': ['2']},*/
     /*'flexible_spec':                 [{
-      'interests': [{'id': '6003384248805', 'name': 'Fitness and wellness'}, {'id': '6003355530237', 'name': 'Gyms'}]
-    }, {'behaviors': [{'id': '6002714895372', 'name': 'All frequent travelers'}], 'relationship_statuses': ['3']}]*/
+     'interests': [{'id': '6003384248805', 'name': 'Fitness and wellness'}, {'id': '6003355530237', 'name': 'Gyms'}]
+     }, {'behaviors': [{'id': '6002714895372', 'name': 'All frequent travelers'}], 'relationship_statuses': ['3']}]*/
   };
 
   showSpec (isVisible, event?) {

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed-targeting-controls.component.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed-targeting-controls.component.ts
@@ -2,6 +2,8 @@ import {
   Component, ChangeDetectionStrategy, Output, EventEmitter, Input, ChangeDetectorRef, OnChanges
 } from '@angular/core';
 
+const isEmpty = require('lodash/isEmpty');
+
 @Component({
   selector:        'fba-detailed-targeting-controls',
   template:        `<div class="fba-detailed-targeting__controls">
@@ -59,8 +61,8 @@ export class DetailedTargetingControlsComponent implements OnChanges {
       this.controls.push(this.excludeControl);
     }
 
-    // Flexible spec is valid if it has at least 1 filled key
-    const validFlexibleSpecs = formValue['flexible_spec'].filter((flexibleSpec) => Object.keys(flexibleSpec).length);
+    // Flexible spec is valid if it is not empty
+    const validFlexibleSpecs = formValue['flexible_spec'].filter((flexibleSpec) => !isEmpty(flexibleSpec));
 
     if (formValue['flexible_spec'].length === validFlexibleSpecs.length && validFlexibleSpecs.length > 0) {
       const control = validFlexibleSpecs.length === 1 ? this.narrowControl : this.narrowFurtherControl;

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed-targeting-wrapper.component.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed-targeting-wrapper.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { TargetingSpec } from '../../interfaces/targeting-spec.interface';
+import { DetailedTargetingSpec, detailedSpecInitial } from '../../interfaces/targeting-spec-detailed.interface';
 
 const isEqual = require('lodash/isEqual');
 
@@ -19,13 +20,14 @@ export class DetailedTargetingWrapperComponent {
   @Input() adaccountId;
   @Output() onChange: EventEmitter<TargetingSpec> = new EventEmitter();
 
-  ngModelChange (spec: TargetingSpec) {
-    const updatedSpec = Object.assign({}, this.spec, spec);
-
-    if (isEqual(updatedSpec, this.spec)) {
+  ngModelChange (detailedSpec: DetailedTargetingSpec) {
+    if (isEqual(this.spec['flexible_spec'], detailedSpec['flexible_spec']) &&
+      isEqual(this.spec['exclusions'], detailedSpec['exclusions'])) {
       return;
     }
 
-    this.onChange.emit(updatedSpec);
+    /*All old keys of detailedSpecInitial should be cleared,
+     because now they are inside flexible_spec*/
+    this.onChange.emit(Object.assign({}, detailedSpecInitial, detailedSpec));
   }
 }

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-dropdown-suggested/detailed-dropdown-suggested.component.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-dropdown-suggested/detailed-dropdown-suggested.component.ts
@@ -61,6 +61,8 @@ export class DetailedDropdownSuggestedComponent implements OnInit, OnDestroy {
     this.detailedInputService.setTerm('');
 
     this.detailedSelectedService.updateSelected(selectedItems);
+
+    this.detailedInputService.setFocus(true);
   }
 
   ngOnDestroy () {

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-input/detailed-input.component.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-input/detailed-input.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy, Input, NgZone } from '@angular/core';
+import {
+  Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy, Input, NgZone, ElementRef
+} from '@angular/core';
 import { DetailedApiService } from '../detailed-api/detailed-api.service';
 import { DetailedModeService } from '../detailed-mode/detailed-mode.service';
 import { DetailedInputService } from './detailed-input.service';
@@ -23,6 +25,7 @@ export class DetailedInputComponent implements OnInit, OnDestroy {
   term;
   mode;
   hasFocus;
+  inputElement;
   structuredSelectedItems;
   activeInfo;
 
@@ -63,6 +66,7 @@ export class DetailedInputComponent implements OnInit, OnDestroy {
                private detailedInputService: DetailedInputService,
                private detailedInfoService: DetailedInfoService,
                private detailedSelectedService: DetailedSelectedService,
+               private elementRef: ElementRef,
                private translateService: TranslateService,
                private changeDetectorRef: ChangeDetectorRef) {
   }
@@ -72,6 +76,8 @@ export class DetailedInputComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit () {
+    this.inputElement = this.elementRef.nativeElement.querySelector('input');
+
     this.detailedInputService.term
         .takeUntil(this.destroy$)
         .debounceTime(500)
@@ -123,6 +129,22 @@ export class DetailedInputComponent implements OnInit, OnDestroy {
         .subscribe((item: DetailedItem) => {
           this.activeInfo = Boolean(item);
           this.changeDetectorRef.markForCheck();
+        });
+
+    this.detailedInputService.hasFocus
+        .takeUntil(this.destroy$)
+        .subscribe((hasFocus: boolean) => {
+          if (hasFocus) {
+            // Set native element focus
+            this.inputElement.focus();
+            // Process focus
+            this.focus();
+          } else {
+            // Blur native element
+            this.inputElement.blur();
+            // Process blur
+            this.blur();
+          }
         });
 
     this.translateService.onLangChange

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-input/detailed-input.service.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-input/detailed-input.service.ts
@@ -7,7 +7,14 @@ export class DetailedInputService {
   _term = new Subject();
   term  = this._term.asObservable();
 
+  _hasFocus = new Subject();
+  hasFocus  = this._hasFocus.asObservable();
+
   setTerm (term: string) {
     this._term.next(term);
+  }
+
+  setFocus (hasFocus: boolean) {
+    this._hasFocus.next(hasFocus);
   }
 }

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-selected/detailed-selected.component.html
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-selected/detailed-selected.component.html
@@ -18,7 +18,7 @@
           <span *ngIf="!last"> &gt; </span>
         </template>
       </div>
-      <span class="fba-detailed-selected__remove detailed-selected__remove-group"
+      <span class="fba-detailed-selected__remove fba-detailed-selected__remove-group"
             (click)="removeGroup(key)">&times;</span>
     </div>
     <div class="detailed-selected__items">

--- a/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-selected/detailed-selected.component.ts
+++ b/src/lib/components/targeting/targeting-form/detailed-targeting/detailed/detailed-selected/detailed-selected.component.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:max-line-length */
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, OnDestroy, NgZone } from '@angular/core';
 import { DetailedSelectedService } from './detailed-selected.service';
 import { DetailedItem } from '../detailed-item';
 import { DetailedModeService } from '../detailed-mode/detailed-mode.service';
@@ -24,7 +24,8 @@ export class DetailedSelectedComponent implements OnInit, OnDestroy {
   structuredSelectedItems;
   groupHovered: Object = {};
 
-  constructor (private detailedService: DetailedService,
+  constructor (private zone: NgZone,
+               private detailedService: DetailedService,
                private detailedDropdownBrowseService: DetailedDropdownBrowseService,
                private detailedModeService: DetailedModeService,
                private detailedSelectedService: DetailedSelectedService,
@@ -53,11 +54,13 @@ export class DetailedSelectedComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Close search mode before opening browse tree
-    this.detailedSearchService.update({isVisible: false, type: null});
+    this.zone.run(() => {
+      // Close search mode before opening browse tree
+      this.detailedSearchService.update({isVisible: false, type: null});
 
-    this.detailedModeService.set('browse');
-    this.detailedDropdownBrowseService.updateOpenItems(openItems);
+      this.detailedModeService.set('browse');
+      this.detailedDropdownBrowseService.updateOpenItems(openItems);
+    });
   }
 
   removeGroup (key) {
@@ -84,6 +87,7 @@ export class DetailedSelectedComponent implements OnInit, OnDestroy {
   hoverGroup (key, isHovered) {
     this.groupHovered[key] = isHovered;
     this.changeDetectorRef.markForCheck();
+    this.changeDetectorRef.detectChanges();
   }
 
   ngOnDestroy () {

--- a/src/lib/components/targeting/targeting-form/geo/geo-map/geo-map.service.spec.ts
+++ b/src/lib/components/targeting/targeting-form/geo/geo-map/geo-map.service.spec.ts
@@ -8,6 +8,7 @@ import { GeoSelectedService } from '../geo-selected/geo-selected.service';
 import { Store } from '@ngrx/store';
 import { GeoApiService } from '../geo-api/geo-api.service';
 import { GeoModeService } from '../geo-mode/geo-mode.service';
+import { GeoSearchService } from '../geo-search/geo-search.service';
 
 describe('Service: GeoMap', () => {
   beforeEach(() => {
@@ -16,6 +17,7 @@ describe('Service: GeoMap', () => {
       providers: [GeoMapService,
         {provide: Store, useValue: {}},
         {provide: TranslateService, useValue: {}},
+        {provide: GeoSearchService, useValue: {}},
         {provide: GeoInfoService, useValue: {}},
         {provide: GeoModeService, useValue: {}},
         {provide: GeoApiService, useValue: {}},

--- a/src/lib/components/targeting/targeting-form/geo/geo-map/geo-map.service.ts
+++ b/src/lib/components/targeting/targeting-form/geo/geo-map/geo-map.service.ts
@@ -13,6 +13,7 @@ import { AppState } from '../../../../../../app/reducers/index';
 import { Store } from '@ngrx/store';
 import { GeoApiService } from '../geo-api/geo-api.service';
 import { ComponentsHelperService } from '../../../../../shared/services/components-helper.service';
+import { GeoSearchService } from '../geo-search/geo-search.service';
 
 @Injectable()
 export class GeoMapService {
@@ -68,12 +69,19 @@ export class GeoMapService {
 
     if (item.type === 'country_group') {
       this.setView(item.latitude, item.longitude);
-      // Show message
-      this.geoInfoService.showInfo({
-        message: this.translateService.instant(`fba-geo-map.COUNTRY_GROUP`, {
-          name: item.name
-        })
-      });
+      // Show message when map is open
+      this._store.let(this.geoSearchService.getModel)
+          .take(1)
+          .map(({isMapOpen}) => isMapOpen)
+          .subscribe((isMapOpen) => {
+            if (isMapOpen) {
+              this.geoInfoService.showInfo({
+                message: this.translateService.instant(`fba-geo-map.COUNTRY_GROUP`, {
+                  name: item.name
+                })
+              });
+            }
+          });
     } else {
       this.map.fitBounds(this.itemsMap[item.key].featureGroup.getBounds());
     }
@@ -236,7 +244,7 @@ export class GeoMapService {
 
           this.togglePinMode();
         });
-  }
+  };
 
   enterPinMode () {
     this.map.on('click', this.onMapClick);
@@ -247,6 +255,7 @@ export class GeoMapService {
   }
 
   constructor (private _store: Store<AppState>,
+               private geoSearchService: GeoSearchService,
                private translateService: TranslateService,
                private geoInfoService: GeoInfoService,
                private geoApiService: GeoApiService,

--- a/src/lib/components/targeting/targeting-form/geo/geo-search/geo-search.service.ts
+++ b/src/lib/components/targeting/targeting-form/geo/geo-search/geo-search.service.ts
@@ -28,7 +28,7 @@ export class GeoSearchService {
                    return geoState[GEO_TARGETING_SEARCH_KEY];
                  })
                  .distinctUntilChanged();
-  }
+  };
 
   focus () {
     this._store.dispatch(this.geoSearchActions.updateModel({hasFocus: true}));

--- a/src/lib/components/targeting/targeting-form/geo/geo-selected/geo-selected.constants.ts
+++ b/src/lib/components/targeting/targeting-form/geo/geo-selected/geo-selected.constants.ts
@@ -21,7 +21,11 @@ export function isNarrower (item: GeoItem, selectedItem: GeoItem) {
     /*passed item is a country of selected item*/
     selectedItem.country_code === item.key ||
     /*passed item is a country group that includes selected item country*/
-    (item.country_codes && item.country_codes.includes(selectedItem.key)) ||
+    (item.country_codes && (
+        item.country_codes.includes(selectedItem.key) ||
+        item.country_codes.includes(selectedItem.country_code)
+      )
+    ) ||
     /*passed item is always narrower than worldwide*/
     selectedItem.is_worldwide ||
     /*passed item is a region of selected item*/
@@ -36,7 +40,11 @@ export function isBroader (item: GeoItem, selectedItem: GeoItem) {
     /*country of passed item is selected*/
     selectedItem.key === item.country_code ||
     /*country group of passed item is selected*/
-    (selectedItem.country_codes && selectedItem.country_codes.includes(item.key)) ||
+    (selectedItem.country_codes && (
+        selectedItem.country_codes.includes(item.key) ||
+        selectedItem.country_codes.includes(item.country_code)
+      )
+    ) ||
     /*worldwide passed item is always broader than any other selected item*/
     item.is_worldwide ||
     /*region of passed item is selected*/

--- a/src/lib/components/targeting/targeting-form/geo/geo-wrapper.component.ts
+++ b/src/lib/components/targeting/targeting-form/geo/geo-wrapper.component.ts
@@ -15,13 +15,12 @@ export class GeoWrapperComponent {
   @Input() spec: TargetingSpec;
   @Output() onChange: EventEmitter<TargetingSpec> = new EventEmitter();
 
-  ngModelChange (spec: TargetingSpec) {
-    const updatedSpec = Object.assign({}, this.spec, spec);
-
-    if (isEqual(updatedSpec, this.spec)) {
+  ngModelChange (geoSpec: TargetingSpec) {
+    if (isEqual(this.spec['geo_locations'], geoSpec['geo_locations']) &&
+      isEqual(this.spec['excluded_geo_locations'], geoSpec['excluded_geo_locations'])) {
       return;
     }
 
-    this.onChange.emit(updatedSpec);
+    this.onChange.emit(geoSpec);
   }
 }


### PR DESCRIPTION
- Show info about country groups only when map is open
- Country groups also replace cities and other smaller than country items
- Support old format of detailed targeting (without flexible spec). Now old format is converted to flexible specs.
- When removing all values from detailed component, the whole control will be removed
- Fix navigation by clicking detailed crumbs
- Fix removing the whole group of items, not just 1 item at once
- Don't emit onChange when the value haven't changed
- Leave focus in input after selecting detailed item