### PR TITLE
Feature/fb api 2.9/952

### DIFF
--- a/src/lib/components/targeting/audience/audience.component.ts
+++ b/src/lib/components/targeting/audience/audience.component.ts
@@ -76,9 +76,9 @@ export class AudienceComponent implements OnInit, OnDestroy {
   ngOnInit () {
     this.audienceForm.patchValue(this.audience);
 
-    this.bidMin    = this.audience.reachestimate.bid_estimations[0].bid_amount_min / 100;
-    this.bidMax    = this.audience.reachestimate.bid_estimations[0].bid_amount_max / 100;
-    this.bidMedian = this.audience.reachestimate.bid_estimations[0].bid_amount_median / 100;
+    this.bidMin    = this.audience.reachestimate.bid_estimate.min_bid / 100;
+    this.bidMax    = this.audience.reachestimate.bid_estimate.max_bid / 100;
+    this.bidMedian = this.audience.reachestimate.bid_estimate.median_bid / 100;
 
     /**
      * Process bid changes, toggle bidAuto and validators when changed

--- a/src/lib/components/targeting/targeting-api/targeting-api.service.ts
+++ b/src/lib/components/targeting/targeting-api/targeting-api.service.ts
@@ -56,15 +56,15 @@ export class TargetingApiService {
   reachestimate (targetingSpec: TargetingSpec, adaccountId = this.adaccountId, optimizeFor = 'IMPRESSIONS') {
     return this.sdk.switchMap((FB: SDK) => {
       return Observable.create((observer) => {
-        FB.api(`/${adaccountId}/reachestimate`, {
+        FB.api(`/${adaccountId}/delivery_estimate`, {
           targeting_spec: targetingSpec,
-          optimize_for:   optimizeFor,
+          optimization_goal:   optimizeFor,
           locale:         this.lang
         }, (response) => {
           if (response.error) {
             observer.error(new SdkError(response.error));
           } else {
-            observer.next(response.data);
+            observer.next(response.data[0]);
             observer.complete();
           }
         });

--- a/src/lib/shared/sdk/sdk.service.ts
+++ b/src/lib/shared/sdk/sdk.service.ts
@@ -55,7 +55,7 @@ export class SdkService {
         status:  true,
         cookie:  true,
         xfbml:   true,
-        version: 'v2.8'
+        version: 'v2.9'
       });
 
       FB.Event.subscribe('auth.statusChange', (response) => {


### PR DESCRIPTION
- change facebook SDK version to 2.9
- replace reachestimate with delivery_estimate in targeting api

https://developers.facebook.com/docs/apps/changelog#mapi_v2_9_breaking
```Removed bid_estimations field from /reach_estimates endpoint and moved all of the documented functionality over to /delivery_estimate```